### PR TITLE
New Multlevel permissions ACL

### DIFF
--- a/src/bootstrap/configure/dashboard.js
+++ b/src/bootstrap/configure/dashboard.js
@@ -1,21 +1,16 @@
 import { get } from 'lodash'
 import store from 'genesis/infra/store/index'
-
 import menu from 'src/bootstrap/menus/drawer'
 import options from 'src/bootstrap/menus/options'
 import configurePath from 'src/bootstrap/configure/path'
 
-/**
- * @param {Vue} $component
- */
 export default ($component) => {
-  const drawer = menu(configurePath)
-  if (!Array.isArray(drawer)) {
+  const items = menu(configurePath)
+  if (!Array.isArray(items)) {
     return false
   }
-
-  store.dispatch('setAppMenu', drawer) // drawer.reduce(permission, [])
-
+  const drawer = items.reduce(reduce, [])
+  store.dispatch('setAppMenu', drawer)
   store.dispatch('setDashboardOptions', options())
 }
 
@@ -24,13 +19,11 @@ export default ($component) => {
  * @param {Object} menu
  * @returns {Array}
  */
-export const permission = (accumulate, menu) => {
+const reduce = (accumulate, menu) => {
   const user = store.getters.getAuthUser
-
   if (menu.children) {
-    menu.children = menu.children.reduce(permission, [])
+    menu.children = menu.children.reduce(reduce, [])
   }
-
   if (!menu.namespace) {
     accumulate.push(menu)
   }

--- a/src/bootstrap/configure/permission.js
+++ b/src/bootstrap/configure/permission.js
@@ -18,13 +18,26 @@ export default ($user, $route, action = null) => {
     return true
   }
   // extract of permissions the access level
-  const expected = parseInt(get(permissions[namespace], 'permission'))
+  const expected = permissions[namespace]
   // intercept in meta the required access level
   let required = parseInt(get($route, 'meta.permission'))
+
   if (action) {
     // when the is to action, get from action the access level required
     required = parseInt(action.permission)
   }
+
+  let verified
   // return granted or not access
-  return required <= expected
+  if (expected) {
+    expected.filter((p) => {
+      if (required === p.permission) {
+        verified = true
+      }
+    })
+    if (verified) {
+      return true
+    }
+  }
+  return false
 }


### PR DESCRIPTION
Atualizado o ACL.
agora com mult niveis de acesso para namespace/roles.
uma namespace/role pode ter varias permissões além das padrões: 1: read, 2: create, 3: update, 4: destroy
caso queira mudar o nivel de um botão add para 10 etc..
nesse caso ele não vai aparecer até você adicionar a permission 10 em algum namespace.

Os menus tem um padrão de nivel 1 read.

Updated the ACL.
now with multi-level access to namespace / roles.
a namespace/role can have multiple permissions beyond the 
defaults: 1: read, 2: create, 3: update, 4: destroy

if you want to change the level of an add button to 10 etc...
in that case it will not appear until you add permission 10 to some namespace.

Menus have a level 1 read standard.